### PR TITLE
Add initial pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,48 @@
+[build-system]
+build-backend = "hatchling.build"
+requires = [
+    "hatchling>=1.10",
+]
+
+[project]
+name = "UVT-ARAMBASA-7E9"
+version = "2025.1"
+description = "Code for my Masters Degree dissertation"
+readme = "README.md"
+keywords = [
+    "dmd",
+    "autoencoder",
+    "mandelbrot",
+    "dynamical-systems",
+]
+license = "MIT"
+maintainers = [{ name = "Vlad Arambașa", email = "vlad.arambasa@e-uvt.ro" }]
+authors = [{ name = "Vlad Arambașa", email = "vlad.arambasa@e-uvt.ro" }]
+requires-python = ">=3.10"
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Science/Research",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Utilities",
+]
+dependencies = [
+    "numpy>=2.1",
+    "scipy>=1.14",
+    "torch",
+    "matplotlib",
+]
+
+[project.urls]
+Repository = "https://github.com/UVT-ARAMBASA/UVT-DISERTATIE-7E9"
+
+[project.optional-dependencies]
+test = [
+    "pytest"
+]
+


### PR DESCRIPTION
This adds an initial `pyproject.toml`, to describe the package and list dependencies. You might need to change some of the metadata in there (at least update the dependencies?) :grin:

You can generate a locked `requirements.txt` file from this, if you want, using e.g. [pip-tools](https://github.com/jazzband/pip-tools/)
```
pip-compile --output-file=requirements.txt pyproject.toml
```
or [uv](https://github.com/astral-sh/uv)
```
uv pip compile --upgrade --universal -o requirements.txt pyproject.toml
```