### PR TITLE
Add initial CI example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typos:
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    name: Spelling (typos)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - uses: crate-ci/typos@master


### PR DESCRIPTION
This adds a little CI that just checks for typos using [typos](https://github.com/crate-ci/typos).

It runs on all pushes to main and in PRs.